### PR TITLE
Make Spree version dependency more restrictive

### DIFF
--- a/spree_it_is_a_present.gemspec
+++ b/spree_it_is_a_present.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 4.2.0', '< 6.0'
+  spree_version = '>= 4.2.0', '< 4.4'
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_api', spree_version
   s.add_dependency 'spree_backend', spree_version


### PR DESCRIPTION
### Summary
Since Spree 4.4 extracted the `backend` and `frontend` parts to external gems, it is no longer safe to make this gem depend on `spree` < 6.0 as the extension generator suggested.

This patch restricts `spree_it_is_a_present` to work in versions of Spree < `4.4`.

Related to #2 