### PR TITLE
Fix dependencies for dummy app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', '~> 4.2.5'
+gem 'sqlite3'
 gem 'rails-controller-testing'
 
 gemspec


### PR DESCRIPTION
### Summary
Since newer versions of Spree are not compatible yet with `spree_it_is_a_present`, fixing these versions makes contributors of the gem able to install the dummy app and run the test suite by executing `bundle exec rake`.